### PR TITLE
Implement multi-cursor handle generation, fix pattern to match Localization folder

### DIFF
--- a/commands/insertHandleUUID.js
+++ b/commands/insertHandleUUID.js
@@ -1,7 +1,6 @@
 const vscode = require('vscode');
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
-
 const { insertText } = require('../support_files/helper_functions');
 const { getConfig } = require('../support_files/config');
 
@@ -19,72 +18,104 @@ let handleDisposable = vscode.commands.registerCommand('bg3-mod-helper.insertHan
 
     const { customWorkspacePath } = getConfig();
 
-    // Capture the selected text and generate a handle for each selection (cursor), using the selected text as the content
-    const handles = await Promise.all(editor.selections.map(selection => {
+    // Generate all handles first
+    const handleData = await Promise.all(editor.selections.map(selection => {
         const selectedText = editor.document.getText(selection);
-        return generateHandle(customWorkspacePath, selectedText);
+        const handle = generateHandle();
+        return { selection, handle, selectedText };
     }));
 
-    // Insert the handles into the editor for each selection
-    editor.edit((editBuilder) => {
-        editor.selections.forEach((selection, index) => {
-            editBuilder.replace(selection, handles[index]);
+    // Collect all the necessary changes for XML files
+    let changes = [];
+    for (const data of handleData) {
+        changes.push({
+            handle: data.handle,
+            text: data.selectedText
         });
+    }
+
+    // Apply edits to the editor first
+    await editor.edit(editBuilder => {
+        for (const data of handleData) {
+            editBuilder.replace(data.selection, data.handle);
+        }
     });
+
+    // Update XML files with all changes (avoid I/O conflicts)
+    if (changes.length > 0) {
+        await updateLocaXmlFiles(changes);
+    }
 });
 
-
-// Function to generate a handle with 'g' included and update .loca.xml file
-async function generateHandle(customWorkspacePath, handleContent) {
-    let tempHandle = 'h' + uuidv4().replace(/-/g, '') + generateRandomHexWithG(4);
-    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-        vscode.window.showWarningMessage(
-            'bg3-mod-helper extension requires a workspace to be set for optimal functionality. Please properly have a workspace set'
-        );
+// Function to update all .loca.xml files in the workspace with the given changes
+async function updateLocaXmlFiles(changes) {
+    const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
+    if (!activeFilePath) {
         return;
     }
-    // Get the path of the currently active file
-    const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
-    if (activeFilePath) {
-        // Determine the workspace folder
-        let workspaceFolder;
-        const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
-        workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(activeFilePath));
 
-        if (workspaceFolder) {
-            // Find .loca.xml file in the workspace folder
-            const locaFilePattern = new vscode.RelativePattern(workspaceFolder, '**/Localization/**/*.xml');
-            const locaFiles = await vscode.workspace.findFiles(locaFilePattern, '**/node_modules/**', 1);
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(activeFilePath));
+    if (!workspaceFolder) {
+        return;
+    }
 
-            if (locaFiles.length == 1) {
-                // Update the first .loca.xml file found
-                const document = await vscode.workspace.openTextDocument(locaFiles[0]);
-                let lines = document.getText().split('\n');
-
-                let indexToInsert = lines.findIndex(line => line.trim() === '</contentList>');
-                if (indexToInsert !== -1) {
-                    const contentToAdd = `    <content contentuid="${tempHandle}" version="1">${handleContent.trim()}</content>\n`;
-                    const edit = new vscode.WorkspaceEdit();
-                    const position = new vscode.Position(indexToInsert, 0);
-                    edit.insert(document.uri, position, contentToAdd);
-                    await vscode.workspace.applyEdit(edit);
-
-                    // Show notification with a button to open the updated .loca.xml file
-                    vscode.window.showInformationMessage('A new handle was created in your .xml file.', 'Open File').then(selection => {
-                        if (selection === 'Open File') {
-                            vscode.window.showTextDocument(document.uri, { preview: false });
-                        }
-                    });
-                }
-            } else {
-                vscode.window.showWarningMessage(
-                    'Either no .xml files found in Localization/*/ or more then 1 was found. Handle not added to .xml file. Maybe you have a .loca.xml file?'
-                );
+    const locaFilePattern = new vscode.RelativePattern(workspaceFolder, '**/Localization/**/*.xml');
+    const locaFiles = await vscode.workspace.findFiles(locaFilePattern, '**/node_modules/**');
+    if (locaFiles.length === 0) {
+        vscode.window.showWarningMessage(`No .xml files found under Localization/. You can create one with the 'Create BG3 File' command.`, 'Create BG3 File').then(selection => {
+            if (selection === 'Create BG3 File') {
+                vscode.commands.executeCommand('bg3-mod-helper.createFileFromTemplate');
             }
+        });
+        return;
+    }
+
+    const edit = new vscode.WorkspaceEdit();
+
+    let nUpdatedFiles = 0;
+    for (const locaFile of locaFiles) {
+        try {
+            await updateLocaXmlFile(locaFile, changes, edit);
+            nUpdatedFiles += 1
+        } catch (error) {
+            console.error(error);
         }
     }
 
-    return tempHandle;
+    vscode.workspace.applyEdit(edit).then(success => {
+        if (!success) {
+            vscode.window.showErrorMessage('Failed to update loca .xml files.');
+        } else {
+            vscode.window.showInformationMessage(`Handles were added to ${nUpdatedFiles} loca .xml files.`)
+        }
+    });
+}
+
+// Function to update a single .loca.xml file with the given changes
+async function updateLocaXmlFile(locaFileUri, changes, edit) {
+    const document = await vscode.workspace.openTextDocument(locaFileUri);
+    let lines = document.getText().split('\n');
+    let indexToInsert = lines.findIndex(line => line.trim() === '</contentList>');
+    if (indexToInsert === -1) {
+        vscode.window.showWarningMessage(`No '</contentList>' tag found in ${locaFileUri.fsPath}. Handle not added to this .xml file.`, 'Open File').then(selection => {
+            if (selection === 'Open File') {
+                vscode.window.showTextDocument(document);
+            }
+        });
+        throw new Error(`No '</contentList>' tag found in ${locaFileUri.fsPath}. Handle not added to this .xml file.`);
+    }
+
+    for (const change of changes) {
+        edit.insert(document.uri, new vscode.Position(indexToInsert, 0), generateContent(change.handle, change.text));
+    }
+}
+
+function generateContent(handle, handleContent) {
+    return `    <content contentuid="${handle}" version="1">${handleContent.trim()}</content>\n`
+}
+
+function generateHandle() {
+    return 'h' + uuidv4().replace(/-/g, '') + generateRandomHexWithG(4);
 }
 
 // Function to generate random hexadecimal characters with 'g' included

--- a/commands/insertHandleUUID.js
+++ b/commands/insertHandleUUID.js
@@ -30,13 +30,12 @@ async function generateHandle(customWorkspacePath) {
     if (activeFilePath) {
         // Determine the workspace folder
         let workspaceFolder;
-        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-            const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
-            workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(activeFilePath));
-        }
+        const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
+        workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(activeFilePath));
+
         if (workspaceFolder) {
             // Find .loca.xml file in the workspace folder
-            const locaFilePattern = new vscode.RelativePattern(workspaceFolder, 'Localization/*/*.xml');
+            const locaFilePattern = new vscode.RelativePattern(workspaceFolder, '**/Localization/**/*.xml');
             const locaFiles = await vscode.workspace.findFiles(locaFilePattern, '**/node_modules/**', 1);
 
             if (locaFiles.length == 1) {

--- a/commands/insertHandleUUID.js
+++ b/commands/insertHandleUUID.js
@@ -11,9 +11,22 @@ let uuidDisposable = vscode.commands.registerCommand('bg3-mod-helper.insertUUID'
 });
 
 let handleDisposable = vscode.commands.registerCommand('bg3-mod-helper.insertHandle', async function () {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active text editor!');
+        return;
+    }
+
     const { customWorkspacePath } = getConfig();
-    const handle = await generateHandle(customWorkspacePath);
-    insertText(handle);
+    // Generate a handle for each selection (cursor)
+    const handles = await Promise.all(editor.selections.map(() => generateHandle(customWorkspacePath)));
+
+    // Insert the handles into the editor for each selection
+    editor.edit((editBuilder) => {
+        editor.selections.forEach((selection, index) => {
+            editBuilder.replace(selection, handles[index]);
+        });
+    });
 });
 
 // Function to generate a handle with 'g' included and update .loca.xml file

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "version": "2.1.10",
     "icon": "media/marketplace_icon.png",
     "engines": {
-        "vscode": "^1.88.0"
+        "vscode": "^1.86.0"
     },
     "categories": [
         "Other"


### PR DESCRIPTION
This PR adds support for multi-cursor handle generation, which allows for generating handles for multiple selections while also using their selected text as content for their respective handle tags in the XML file.
I also changed the pattern to match the Localization folder since it was not working on my end, I believe it should be fine now.

(I removed a redundant check from `generateHandle` since it already has an early return)