### PR TITLE
chore: use more human-readable name for extension's `displayName`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bg3-mod-helper",
-    "displayName": "bg3_mod_helper",
+    "displayName": "BG3 Mod Helper",
     "publisher": "ghostboats",
     "description": "This extension is designed to help you make mods in Baldur's Gate 3 by creating UUIDs and handles for you, as well as updating your .loca.xml files as well should they exist. And more to come in the future.",
     "version": "2.2.3",


### PR DESCRIPTION
This PR updates the display name of the extension from "bg3_mod_helper" to "BG3 Mod Helper", since it is the user-facing name.